### PR TITLE
fix: Return 400 for data validation errors instead of 500

### DIFF
--- a/error-handling-improvements.md
+++ b/error-handling-improvements.md
@@ -88,16 +88,22 @@ This document outlines the error handling improvements made to the FAIVOR-ML-Val
 
 ## Error Code Reference
 
+### Client Errors (4xx)
 - `INVALID_METADATA_JSON`: Malformed JSON in metadata
 - `METADATA_PARSE_ERROR`: Valid JSON but invalid metadata structure
 - `INVALID_CSV_FORMAT`: CSV parsing errors
 - `CSV_READ_ERROR`: File reading issues
 - `MISSING_REQUIRED_COLUMNS`: Required columns not found in CSV
-- `CONTAINER_EXECUTION_ERROR`: Docker container failures
-- `MODEL_EXECUTION_TIMEOUT`: Execution time exceeded
-- `MODEL_EXECUTION_FAILED`: Model returned error status
-- `METRICS_CALCULATION_ERROR`: Failed to compute metrics
-- `METRICS_CALCULATOR_INIT_ERROR`: Failed to initialize calculator
+- `DATA_VALIDATION_ERROR`: Model rejected input data (invalid/out-of-range values)
+- `MODEL_PROCESSING_ERROR`: Model failed to process input data (status code 4)
+
+### Server Errors (5xx)
+- `CONTAINER_EXECUTION_ERROR`: Docker container failures (503)
+- `MODEL_EXECUTION_TIMEOUT`: Execution time exceeded (503)
+- `MODEL_EXECUTION_FAILED`: Model returned error status (500)
+- `MODEL_EXECUTION_ERROR`: Unexpected error during execution (500)
+- `METRICS_CALCULATION_ERROR`: Failed to compute metrics (500)
+- `METRICS_CALCULATOR_INIT_ERROR`: Failed to initialize calculator (500)
 
 ## Testing Recommendations
 


### PR DESCRIPTION
## Summary
- When models reject input data due to invalid/out-of-range values, the API now returns HTTP 400 (client error) instead of 500 (server error)
- Added two new error codes: `DATA_VALIDATION_ERROR` and `MODEL_PROCESSING_ERROR`
- Updated error handling documentation

## Changes
- **run_docker.py**: Catch HTTP errors from model `/predict` endpoint and distinguish between 4xx (data validation) and 5xx (server) errors
- **api_controller.py**: Add handlers for `ValueError` (DATA_VALIDATION_ERROR) and model processing failures (MODEL_PROCESSING_ERROR) with status 400
- **error-handling-improvements.md**: Updated with new error codes

## Test plan
- [ ] Test with valid data - should return 200 with metrics
- [ ] Test with invalid/out-of-range values - should return 400 with DATA_VALIDATION_ERROR
- [ ] Test with container failures - should return 503 with CONTAINER_EXECUTION_ERROR

Fixes MaastrichtU-BISS/FAIVOR-Dashboard#18